### PR TITLE
Removed depreciated getInnerHtml() function

### DIFF
--- a/spec/Index.spec.js
+++ b/spec/Index.spec.js
@@ -18,7 +18,7 @@ describe('Filters Test', function() {
 		var todoList = element.all(by.repeater('contact in ctrl.contacts'));
 		var item = todoList.get(0).element(by.css('td:nth-child(6)'));
 
-		expect(item.getInnerHtml()).toBe('Tuesday, January 13, 1970');
+		expect(browser.executeScript("return arguments[0].innerHTML;", item)).toBe('Tuesday, January 13, 1970');
 	});
 
 


### PR DESCRIPTION
With the latest 5.0.0 update to protractor, the `getInnerHtml()` function has been removed. I've updated the spec to reflect the replacement to the method as per the protractor changelog listed below.

https://github.com/angular/protractor/blob/master/CHANGELOG.md

@aturkewi 